### PR TITLE
docs: CONTEXT.md and ADR 0001 — the guest kernel is a host resource

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,34 @@
+# Pyro
+
+A Firecracker microVM sandbox platform for AI agents. Pyro runs on a single Linux
+host with native `/dev/kvm`, boots one microVM per sandbox, and exposes them over
+an HTTP API.
+
+## Language
+
+**Sandbox**:
+One Firecracker microVM with a lifetime, owned by the API key that created it.
+_Avoid_: VM, instance, container
+
+**Base image**:
+A named, rootfs-only ext4 filesystem a sandbox boots from. A base image never
+carries a kernel.
+_Avoid_: Image (unqualified, when a Docker image is meant), template
+
+**Guest kernel**:
+The single `vmlinux` a host boots every sandbox with, named by the server's
+`--kernel` flag. It belongs to the host, not to a base image, and is not
+selectable per sandbox. See `docs/adr/0001-guest-kernel-is-a-host-resource.md`.
+_Avoid_: Kernel version, kernel image (both imply a selectable set)
+
+**Host readiness**:
+Whether a host can actually boot a sandbox — `/dev/kvm`, the `firecracker`
+binary, the bridge with IP forwarding, a guest kernel, at least one base image,
+and root. Distinct from `/api/health`, which reports only that the server process
+is answering.
+_Avoid_: Health, preflight (reserve `preflight` for the startup check itself)
+
+**pyro-agent**:
+The in-VM binary that runs as PID 1 and serves the vsock protocol. A sandbox's
+base image never runs its own `CMD` or `ENTRYPOINT`.
+_Avoid_: Init, guest agent

--- a/docs/adr/0001-guest-kernel-is-a-host-resource.md
+++ b/docs/adr/0001-guest-kernel-is-a-host-resource.md
@@ -1,0 +1,49 @@
+# The guest kernel is a host resource, not a per-sandbox choice
+
+A pyro host has exactly one guest kernel, at the path given by `--kernel`
+(default `/opt/pyro/images/vmlinux`). Base images are rootfs-only. There is no
+per-image kernel, no versioned kernel store, and no way for a caller to pick a
+kernel per sandbox.
+
+## Context
+
+Three incompatible layouts for the same word coexisted in the tree: an
+image-owned kernel (`<name>/vmlinux`, asserted by the `internal/sandbox/images.go`
+package doc), a shared host kernel (`images/vmlinux`, what `pyro build-kernel`,
+`pyro doctor` and both systemd units actually use), and a versioned listable
+store (`images/vmlinux-<version>`, which `ListKernels` scanned for and **no code
+path ever wrote**).
+
+The third layout was not merely unused — it broke the product. `handleCreateSandbox`
+called `ResolveKernel` on every create, `ResolveKernel` delegated to `ListKernels`,
+and `ListKernels` matched only `vmlinux-<version>`. On any host provisioned the
+documented way, every `POST /sandboxes` returned
+`400 {"error":"kernel: no kernels found in /opt/pyro/images"}`, and the `--kernel`
+flag was never consulted. Unit tests stayed green because no fixture wrote a
+versioned kernel name and no test exercised the create path with an image manager
+attached.
+
+## Decision
+
+The host-singular layout wins, because it is the only one anything writes.
+Removed: `ListKernels`, `ResolveKernel`, `GET /kernels`, the `kernel` field on
+`CreateSandboxRequest`, the per-image kernel fallback in `ImageManager.Get`, and
+the kernel selector in the dashboard. `Manager.CreateSandbox` already fell back to
+the configured `--kernel` when `VMResources.KernelPath` was empty, so restoring the
+create path meant deleting the resolution call, not adding a fallback.
+
+## Considered options
+
+A host-level versioned store — teach `pyro build-kernel` to write
+`vmlinux-<version>` and redefine `--kernel` as "latest from the store" — was
+rejected. It would touch `build-kernel`, `doctor`, both service units, the router
+and the UI to deliver per-sandbox kernel choice that no caller has ever asked for.
+Widening `ListKernels` to also match bare `vmlinux` was rejected as a patch that
+leaves the vocabulary conflict in place.
+
+## Consequences
+
+`kernel` disappearing from `CreateSandboxRequest` is visible to SDK users who set
+it. Changing the host's kernel is a `--kernel` change plus a server restart, and
+it applies to every sandbox at once. Reintroducing per-sandbox kernel selection is
+additive but is a deliberate reversal of this ADR, not a gap to be filled in.


### PR DESCRIPTION
Records the domain decision settled while grilling #29.

- `CONTEXT.md` — first glossary for the repo. Five terms: sandbox, base image, guest kernel, host readiness, pyro-agent.
- `docs/adr/0001-guest-kernel-is-a-host-resource.md` — a guest kernel is a host resource named by `--kernel`; base images are rootfs-only.

The ADR settles a three-way conflict over one word that was breaking the product: `internal/sandbox/images.go`'s package doc claimed an image owns a kernel, `build-kernel`/`doctor`/both units use a shared `images/vmlinux`, and `ListKernels` scanned for `images/vmlinux-<version>` — a name nothing in the tree ever writes. Because `handleCreateSandbox` called `ResolveKernel` unconditionally, every `POST /sandboxes` on a provisioned host returned `400 kernel: no kernels found`.

Docs only, no code change. The code change is #30.

Closes nothing on its own — #29 tracks the discovery, #30 through #33 the work.
