### PR TITLE
Kernel resolution: collapse to a host-owned kernel and restore POST /sandboxes

### DIFF
--- a/internal/api/images.go
+++ b/internal/api/images.go
@@ -16,21 +16,6 @@ func SetupImageRoutes(r chi.Router, imgMgr *sandbox.ImageManager) {
 	r.Get("/images", handleListImages(imgMgr))
 	r.Get("/images/{name}", handleGetImage(imgMgr))
 	r.Post("/images", handleCreateImage(imgMgr))
-	r.Get("/kernels", handleListKernels(imgMgr))
-}
-
-func handleListKernels(imgMgr *sandbox.ImageManager) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		kernels, err := imgMgr.ListKernels()
-		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-			return
-		}
-		if kernels == nil {
-			kernels = []*sandbox.KernelInfo{}
-		}
-		writeJSON(w, http.StatusOK, kernels)
-	}
 }
 
 func handleListImages(imgMgr *sandbox.ImageManager) http.HandlerFunc {

--- a/internal/api/images_test.go
+++ b/internal/api/images_test.go
@@ -52,6 +52,19 @@ func postImage(t *testing.T, r http.Handler, body any) *httptest.ResponseRecorde
 	return w
 }
 
+// TestKernelsRoute_Gone asserts GET /kernels is no longer registered: the
+// guest kernel is a host resource named by --kernel, not something callers
+// list or select.
+func TestKernelsRoute_Gone(t *testing.T) {
+	r := newImageRouter(t)
+	req := httptest.NewRequest("GET", "/kernels", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d want 404; body=%s", w.Code, w.Body.String())
+	}
+}
+
 func TestCreateImage_RejectsBothSourceAndDockerfile(t *testing.T) {
 	r := newImageRouter(t)
 	w := postImage(t, r, map[string]string{

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -170,10 +170,9 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 type CreateSandboxRequest struct {
 	TTL            int    `json:"ttl"`                        // seconds
 	Image          string `json:"image"`                      // rootfs image name (default: "default")
-	Kernel         string `json:"kernel,omitempty"`            // kernel version (default: latest)
-	VCPU           int    `json:"vcpu,omitempty"`              // vCPU count (0 = image/server default)
-	MemMiB         int    `json:"mem_mib,omitempty"`           // memory in MiB (0 = image/server default)
-	ScratchSizeMiB int    `json:"scratch_size_mib,omitempty"`  // ephemeral scratch disk in MiB (0 = none)
+	VCPU           int    `json:"vcpu,omitempty"`             // vCPU count (0 = image/server default)
+	MemMiB         int    `json:"mem_mib,omitempty"`          // memory in MiB (0 = image/server default)
+	ScratchSizeMiB int    `json:"scratch_size_mib,omitempty"` // ephemeral scratch disk in MiB (0 = none)
 }
 
 func (s *Server) handleCreateSandbox(w http.ResponseWriter, r *http.Request) {
@@ -218,17 +217,6 @@ func (s *Server) handleCreateSandbox(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Resolve kernel version — empty means latest.
-	kernelPath := ""
-	if s.imageMgr != nil {
-		kp, err := s.imageMgr.ResolveKernel(req.Kernel)
-		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "kernel: " + err.Error()})
-			return
-		}
-		kernelPath = kp
-	}
-
 	ak := APIKeyFromContext(r.Context())
 	ttl := time.Duration(req.TTL) * time.Second
 
@@ -243,7 +231,6 @@ func (s *Server) handleCreateSandbox(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	sb, err := s.manager.CreateSandbox(r.Context(), ak.ID, image, ttl, sandbox.VMResources{
 		VCPU:           req.VCPU,
-		KernelPath:     kernelPath,
 		MemMiB:         req.MemMiB,
 		ScratchSizeMiB: req.ScratchSizeMiB,
 	})

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -3,10 +3,12 @@ package api
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -249,5 +251,56 @@ func TestCreateSandbox_RejectsNonReadyImage(t *testing.T) {
 				t.Errorf("body does not surface reason %q: %s", tc.wantInBody, w.Body.String())
 			}
 		})
+	}
+}
+
+// TestCreateSandbox_NotRejectedOnKernelGrounds is the issue #30 regression
+// test: an images dir laid out the way `pyro build-kernel` (host-shared
+// vmlinux) and `POST /images` (per-image rootfs.ext4, no per-image kernel)
+// actually leave it. On main, handleCreateSandbox called ResolveKernel,
+// which only matched a versioned kernel filename and never the bare vmlinux
+// build-kernel writes, so every create failed 400 "kernel: no kernels
+// found". The guest kernel is a host resource (--kernel), not resolved
+// per request, so this must never be rejected on kernel grounds.
+func TestCreateSandbox_NotRejectedOnKernelGrounds(t *testing.T) {
+	imagesDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(imagesDir, "vmlinux"), []byte("kernel"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	imgDir := filepath.Join(imagesDir, "myimage")
+	if err := os.MkdirAll(imgDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(imgDir, "rootfs.ext4"), []byte("rootfs"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	imgMgr, err := sandbox.NewImageManager(sandbox.ImageConfig{ImagesDir: imagesDir}, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	st := setupTestStore(t)
+	mgr, err := sandbox.New(sandbox.Config{
+		StateDir:   t.TempDir(),
+		ImagesDir:  imagesDir,
+		BridgeName: "pyro-test-br0",
+	}, st, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("POST", "/sandboxes", strings.NewReader(`{"ttl":60,"image":"myimage"}`))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := context.WithValue(req.Context(), apiKeyContextKey, &store.APIKey{ID: "test-key-id"})
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	s := &Server{manager: mgr, imageMgr: imgMgr, store: st, log: log}
+	s.handleCreateSandbox(w, req)
+
+	if w.Code == http.StatusBadRequest && strings.Contains(w.Body.String(), "kernel") {
+		t.Fatalf("request rejected on kernel grounds: %d %s", w.Code, w.Body.String())
 	}
 }

--- a/internal/sandbox/images.go
+++ b/internal/sandbox/images.go
@@ -1,24 +1,21 @@
 // Package sandbox — images.go manages base images for sandboxes.
 //
-// Images are stored as rootfs.ext4 + vmlinux kernel pairs.
-// Each image has a name, and sandboxes reference images by name.
+// Base images are rootfs-only. The guest kernel is a host resource named
+// by the server's --kernel flag, not an image concern — see
+// docs/adr/0001-guest-kernel-is-a-host-resource.md.
 //
 // Directory layout:
 //
 //	{ImagesDir}/
 //	  ├── default/
-//	  │   ├── rootfs.ext4
-//	  │   └── vmlinux
+//	  │   └── rootfs.ext4
 //	  ├── python312/
-//	  │   ├── rootfs.ext4
-//	  │   └── vmlinux
+//	  │   └── rootfs.ext4
 //	  └── node22/
-//	      ├── rootfs.ext4
-//	      └── vmlinux
+//	      └── rootfs.ext4
 package sandbox
 
 import (
-	"cmp"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -28,8 +25,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -150,70 +145,6 @@ func NewImageManager(cfg ImageConfig, log *slog.Logger) (*ImageManager, error) {
 // in-flight and recently-failed pull state.
 func (im *ImageManager) Ledger() *imagestate.Ledger { return im.ledger }
 
-// KernelInfo describes an available guest kernel.
-type KernelInfo struct {
-	Version string `json:"version"`
-	Path    string `json:"path"`
-	Size    int64  `json:"size"`
-}
-
-// ListKernels returns all vmlinux-* kernels in the images dir, sorted by version descending.
-func (im *ImageManager) ListKernels() ([]*KernelInfo, error) {
-	entries, err := os.ReadDir(im.cfg.ImagesDir)
-	if err != nil {
-		return nil, fmt.Errorf("read images dir: %w", err)
-	}
-
-	var kernels []*KernelInfo
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		version, ok := strings.CutPrefix(name, "vmlinux-")
-		if !ok {
-			continue
-		}
-		path := filepath.Join(im.cfg.ImagesDir, name)
-		info, err := entry.Info()
-		if err != nil {
-			continue
-		}
-		kernels = append(kernels, &KernelInfo{
-			Version: version,
-			Path:    path,
-			Size:    info.Size(),
-		})
-	}
-
-	// Sort descending by version string (higher versions first).
-	slices.SortFunc(kernels, func(a, b *KernelInfo) int {
-		return cmp.Compare(b.Version, a.Version)
-	})
-
-	return kernels, nil
-}
-
-// ResolveKernel returns the path for a kernel version, or the latest if version is empty.
-func (im *ImageManager) ResolveKernel(version string) (string, error) {
-	kernels, err := im.ListKernels()
-	if err != nil {
-		return "", err
-	}
-	if len(kernels) == 0 {
-		return "", fmt.Errorf("no kernels found in %s", im.cfg.ImagesDir)
-	}
-	if version == "" {
-		return kernels[0].Path, nil // latest (sorted descending)
-	}
-	for _, k := range kernels {
-		if k.Version == version {
-			return k.Path, nil
-		}
-	}
-	return "", fmt.Errorf("kernel version %q not found", version)
-}
-
 // List returns all available images.
 func (im *ImageManager) List() ([]*ImageInfo, error) {
 	entries, err := os.ReadDir(im.cfg.ImagesDir)
@@ -239,27 +170,16 @@ func (im *ImageManager) List() ([]*ImageInfo, error) {
 func (im *ImageManager) Get(name string) (*ImageInfo, error) {
 	dir := filepath.Join(im.cfg.ImagesDir, name)
 	rootfs := filepath.Join(dir, "rootfs.ext4")
-	kernel := filepath.Join(dir, "vmlinux")
 
 	rootfsInfo, err := os.Stat(rootfs)
 	if err != nil {
 		return nil, fmt.Errorf("rootfs not found for image %q: %w", name, err)
 	}
 
-	// Fall back to shared kernel in images root if no per-image kernel.
-	if _, err := os.Stat(kernel); err != nil {
-		shared := filepath.Join(im.cfg.ImagesDir, "vmlinux")
-		if _, err := os.Stat(shared); err != nil {
-			return nil, fmt.Errorf("kernel not found for image %q: %w", name, err)
-		}
-		kernel = shared
-	}
-
 	info := &ImageInfo{
 		Name:       name,
 		Status:     imagestate.StatusReady,
 		RootfsPath: rootfs,
-		KernelPath: kernel,
 		Size:       rootfsInfo.Size(),
 		CreatedAt:  rootfsInfo.ModTime(),
 	}

--- a/internal/sandbox/images_kernel_test.go
+++ b/internal/sandbox/images_kernel_test.go
@@ -1,0 +1,56 @@
+package sandbox
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestGet_RootfsOnly_NoPerImageKernel_Succeeds asserts base images are
+// rootfs-only: Get() must succeed on an image dir with a rootfs and no
+// kernel anywhere (no per-image vmlinux, no shared vmlinux), because the
+// guest kernel is a host resource named by --kernel, not an image concern.
+func TestGet_RootfsOnly_NoPerImageKernel_Succeeds(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "myimage")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "rootfs.ext4"), []byte("rootfs"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	im, err := NewImageManager(ImageConfig{ImagesDir: root}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := im.Get("myimage")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if info.RootfsPath == "" {
+		t.Error("expected rootfs path to be set")
+	}
+}
+
+// TestGet_NoRootfs_StillErrors asserts the one thing Get() still requires
+// after the kernel fallback is deleted: a rootfs.
+func TestGet_NoRootfs_StillErrors(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "empty")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	im, err := NewImageManager(ImageConfig{ImagesDir: root}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := im.Get("empty"); err == nil {
+		t.Fatal("expected error for missing rootfs")
+	}
+}

--- a/ui/src/routes/sandboxes/+page.svelte
+++ b/ui/src/routes/sandboxes/+page.svelte
@@ -3,12 +3,10 @@
 	import { subscribe } from '$lib/events.svelte.js';
 
 	let sandboxes = $state([]);
-	let kernels = $state([]);
 	let error = $state('');
 	let creating = $state(false);
 	let newTTL = $state(3600);
 	let newImage = $state('default');
-	let newKernel = $state('');
 	let newVCPU = $state(1);
 	let newMemMiB = $state(256);
 	let newScratchMiB = $state(0);
@@ -19,13 +17,6 @@
 			if (res.ok) sandboxes = await res.json();
 			error = '';
 		} catch (e) { error = e.message; }
-	}
-
-	async function fetchKernels() {
-		try {
-			const res = await apiFetch('/kernels');
-			if (res.ok) kernels = await res.json();
-		} catch {}
 	}
 
 	$effect(() => {
@@ -45,7 +36,6 @@
 		creating = true;
 		try {
 			const body = { ttl: newTTL, image: newImage, vcpu: newVCPU, mem_mib: newMemMiB };
-			if (newKernel) body.kernel = newKernel;
 			if (newScratchMiB > 0) body.scratch_size_mib = newScratchMiB;
 			const res = await apiFetch('/sandboxes', {
 				method: 'POST',
@@ -84,7 +74,6 @@
 	}
 
 	refresh();
-	fetchKernels();
 </script>
 
 <div class="page-header">
@@ -110,15 +99,6 @@
 				<option value="ubuntu">ubuntu</option>
 				<option value="python">python</option>
 				<option value="node">node</option>
-			</select>
-		</div>
-		<div class="field">
-			<label for="kernel-select">Kernel</label>
-			<select id="kernel-select" bind:value={newKernel}>
-				<option value="">latest</option>
-				{#each kernels as k}
-					<option value={k.version}>{k.version}</option>
-				{/each}
 			</select>
 		</div>
 		<div class="field">


### PR DESCRIPTION
Closes #30

## What

Collapses guest-kernel resolution to a single host-owned kernel named by `--kernel`, and restores `POST /sandboxes`. Base images become rootfs-only. This is a deletion, not a patch — the versioned-kernel apparatus goes out whole:

- Deleted the `ResolveKernel` call at `handleCreateSandbox` (was `internal/api/router.go:222-229`). `kernelPath` is left empty — `internal/sandbox/manager.go:263-266` already falls back to `m.cfg.KernelPath`.
- Deleted `ListKernels` and `ResolveKernel` (`internal/sandbox/images.go`).
- Deleted `GET /kernels` and `KernelInfo` (`internal/api/images.go`).
- Deleted `CreateSandboxRequest.Kernel`.
- Deleted the per-image kernel fallback in `ImageManager.Get`, and corrected the package doc to say base images are rootfs-only.
- Deleted the kernel selector from `ui/src/routes/sandboxes/+page.svelte` — `kernels` state, `fetchKernels`, the `<select>`, and `body.kernel`.

## Why

Every `POST /sandboxes` returned `400 {"error":"kernel: no kernels found in /opt/pyro/images"}` on any host provisioned the documented way: `pyro build-kernel` writes `images/vmlinux` (no version suffix), but `ListKernels` only matched `vmlinux-<version>`, which nothing ever wrote. The `--kernel` flag was never consulted on the create path. See `docs/adr/0001-guest-kernel-is-a-host-resource.md`.

## SDK impact (breaking change, auto-published)

`kernel` disappearing from `CreateSandboxRequest` is a published breaking change to the request schema — merging to `main` auto-publishes both SDKs via `.github/workflows/release.yml`. Neither SDK sends `kernel` today, so no SDK code changes were needed. `ImageInfo.kernel_path` (read by both SDKs) is unaffected — the field stays in the Go struct and both SDK models already default it to `""`; it's just never populated now that base images don't carry a kernel.

## Test evidence

**Base sha `2ae63f0`** (before this change), full suite:

```
pyro-tests: DISCOVERED=121 RAN=121 PASS=121 FAIL=0 SKIP=0 sha=2ae63f0
```

**Regression test run against base sha** (test copied into a clone checked out at `2ae63f0`, production code unchanged) — fails exactly as the issue describes:

```
=== RUN   TestCreateSandbox_NotRejectedOnKernelGrounds
    router_test.go:304: request rejected on kernel grounds: 400 {"error":"kernel: no kernels found in /tmp/TestCreateSandbox_NotRejectedOnKernelGrounds2420080700/001"}
--- FAIL: TestCreateSandbox_NotRejectedOnKernelGrounds (0.00s)
FAIL
FAIL	github.com/danievanzyl/pyro/internal/api	0.024s
FAIL
```

**PR head `4e4dc3b376eb3ec938f76cb442367683846efa1a`**, full suite:

```
pyro-tests: DISCOVERED=125 RAN=125 PASS=125 FAIL=0 SKIP=0 sha=4e4dc3b376eb3ec938f76cb442367683846efa1a
```

**Per-test-name diff, base vs. head** (`go test -short -v ./internal/...`, every `--- PASS/FAIL/SKIP` line including subtests):

- Tests present at base and absent at head: **none**.
- Tests present at base that flipped from PASS to FAIL at head: **none**.
- Tests added at head (all new, none replace a base test): `TestCreateSandbox_NotRejectedOnKernelGrounds`, `TestKernelsRoute_Gone`, `TestGet_RootfsOnly_NoPerImageKernel_Succeeds`, `TestGet_NoRootfs_StillErrors`.

## Intended test removals

None. `ListKernels`, `ResolveKernel`, and `KernelInfo` had no dedicated unit tests on `main` (confirmed by grep across `*_test.go`), so no test names disappear.

## Acceptance criteria

- [x] A create against an images dir containing `images/vmlinux` and `<name>/rootfs.ext4` reaches `Manager.CreateSandbox` with `VMResources.KernelPath == ""` — `router.go` no longer computes or sets `KernelPath` in the `VMResources` literal, so it's the zero value. Actually booting with `--kernel` requires a KVM host and is out of scope per the issue (same as `make test`).
- [x] Regression test in `internal/api` (`TestCreateSandbox_NotRejectedOnKernelGrounds`) builds that exact layout, drives `handleCreateSandbox`, and fails on `main` with the exact 400 kernel error quoted above.
- [x] `grep -rn "vmlinux-" --include=*.go .` matches only `cmd/pyro/build.go:231` (FC CI download URL).
- [x] `GET /kernels` returns 404 — `TestKernelsRoute_Gone`.
- [x] `ImageManager.Get`: errors with no `rootfs.ext4` (`TestGet_NoRootfs_StillErrors`); succeeds with a rootfs and no per-image `vmlinux` anywhere, without consulting any kernel path (`TestGet_RootfsOnly_NoPerImageKernel_Succeeds`).
- [x] `make test-unit` passes; `bun run build` in `ui/` succeeds.

## Review checklist

1. **Correctness** — passes. Matches the locked design line-for-line; `make test-unit` and `go vet ./...` are green; UI builds.
2. **Scope fidelity** — passes. Every changed line is one of the deletions the issue names, or a test/doc-comment covering an acceptance criterion. Nothing else touched.
3. **Regression safety** — passes. Per-test-name diff above shows zero flips and zero silent removals between base and head; adjacent image-lifecycle tests (`TestGet_LabelsFromSidecar`, `TestCreateFromRegistry_*`, etc.) still pass unchanged.
4. **Test quality** — passes. `TestCreateSandbox_NotRejectedOnKernelGrounds` is demonstrated to fail on `main` with the exact bug from the issue; `TestGet_RootfsOnly_NoPerImageKernel_Succeeds` fails without the fix (was red before the `Get` edit); `TestKernelsRoute_Gone` fails if the route is ever re-added.
5. **Lean** — `ponytail-review` found nothing to cut inside the issue's scope. Two out-of-scope findings noted and deliberately left: `ImageInfo.KernelPath` stays as an always-empty field (kept for the SDK-compat reason the issue itself states), and the dead per-image kernel copy in `CreateFromDockerfile`/`runRegistryPull` is untouched because it's outside the issue's named deletion list.
