### PR TITLE
Fix sidecar filename, store.New MkdirAll, and /api prefix in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,26 +31,29 @@ make test           # full tests (requires Linux + KVM)
 
 ## API Endpoints
 
+All routes live under `/api`.
+
 ### Sandbox Lifecycle
-- `POST /sandboxes` — create sandbox with TTL
-- `GET /sandboxes` — list active sandboxes
-- `GET /sandboxes/{id}` — get sandbox details
-- `DELETE /sandboxes/{id}` — destroy sandbox
-- `POST /sandboxes/{id}/exec` — execute command (sync)
-- `PUT /sandboxes/{id}/files/*` — write file into sandbox
-- `GET /sandboxes/{id}/files/*` — read file from sandbox
-- `GET /sandboxes/{id}/ws?api_key=KEY` — WebSocket streaming exec
+- `POST /api/sandboxes` — create sandbox with TTL
+- `GET /api/sandboxes` — list active sandboxes
+- `GET /api/sandboxes/{id}` — get sandbox details
+- `DELETE /api/sandboxes/{id}` — destroy sandbox
+- `POST /api/sandboxes/{id}/exec` — execute command (sync)
+- `PUT /api/sandboxes/{id}/files/*` — write file into sandbox
+- `GET /api/sandboxes/{id}/files/*` — read file from sandbox
+- `GET /api/sandboxes/{id}/ws?api_key=KEY` — WebSocket streaming exec
 
 ### Images
-- `GET /images` — list base images
-- `GET /images/{name}` — get image info
-- `POST /images` — create image from Dockerfile
+- `GET /api/images` — list base images
+- `GET /api/images/{name}` — get image info
+- `POST /api/images` — create image from Dockerfile
 
 ### Streaming
-- `GET /events?api_key=KEY` — SSE event stream (sandbox lifecycle + health ticks)
+- `GET /api/events?api_key=KEY` — SSE event stream (sandbox lifecycle + health ticks)
 
 ### System
-- `GET /health` — health check
+- `GET /api/health` — health check
+- `GET /health` — backward-compat alias for `/api/health`
 
 ## Security Notes
 

--- a/cmd/pyro/build.go
+++ b/cmd/pyro/build.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -205,16 +208,7 @@ func buildFromOCI(name, ociRef string, sizeMB int, postPkgs []string, postCmds [
 	cleanup(mnt, rootfs)
 
 	// Write image metadata
-	meta := map[string]any{
-		"name":   name,
-		"source": ociRef,
-		"size":   sizeMB,
-	}
-	metaJSON, _ := json.MarshalIndent(meta, "", "  ")
-	if err := os.WriteFile(filepath.Join(imgDir, "image.json"), metaJSON, 0644); err != nil {
-		fmt.Fprintf(os.Stderr, "error: write image.json: %v\n", err)
-		os.Exit(1)
-	}
+	writeImageSidecar(imgDir, name, ociRef, sizeMB, rootfs)
 
 	fmt.Printf("==> %s image complete\n", name)
 }
@@ -259,7 +253,6 @@ func buildMinimal() {
 
 	createRootfs(rootfs, 50)
 	mnt := mustMount(rootfs)
-	defer cleanup(mnt, rootfs)
 
 	for _, d := range []string{"bin", "sbin", "usr/bin", "usr/sbin", "dev", "proc", "sys", "etc", "tmp", "root", "var/log"} {
 		os.MkdirAll(filepath.Join(mnt, d), 0755)
@@ -290,12 +283,8 @@ func buildMinimal() {
 	writeFile(filepath.Join(mnt, "etc/passwd"), "root:x:0:0:root:/root:/bin/sh\n")
 	writeFile(filepath.Join(mnt, "etc/group"), "root:x:0:\n")
 
-	meta := map[string]any{"name": "minimal", "source": "busybox-static", "size": 50}
-	metaJSON, _ := json.MarshalIndent(meta, "", "  ")
-	if err := os.WriteFile(filepath.Join(imgDir, "image.json"), metaJSON, 0644); err != nil {
-		fmt.Fprintf(os.Stderr, "error: write image.json: %v\n", err)
-		os.Exit(1)
-	}
+	cleanup(mnt, rootfs)
+	writeImageSidecar(imgDir, "minimal", "busybox-static", 50, rootfs)
 
 	fmt.Println("==> Minimal image complete")
 }
@@ -392,6 +381,45 @@ func cleanup(mnt, rootfs string) {
 	if info, err := os.Stat(rootfs); err == nil {
 		fmt.Printf("    rootfs: %s (%.0f MB)\n", rootfs, float64(info.Size())/1024/1024)
 	}
+}
+
+// imageMetaName mirrors the server's sidecar filename (internal/sandbox
+// reads image-meta.json for Source/Digest/Labels).
+const imageMetaName = "image-meta.json"
+
+// writeImageSidecar persists the image-meta.json sidecar so ImageManager.Get
+// can surface Source and Digest for CLI-built images.
+func writeImageSidecar(imgDir, name, source string, sizeMB int, rootfsPath string) {
+	digest, err := fileDigest(rootfsPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warn: digest %s: %v\n", rootfsPath, err)
+	}
+	meta := map[string]any{
+		"name":   name,
+		"source": source,
+		"size":   sizeMB,
+		"digest": digest,
+	}
+	metaJSON, _ := json.MarshalIndent(meta, "", "  ")
+	if err := os.WriteFile(filepath.Join(imgDir, imageMetaName), metaJSON, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "error: write %s: %v\n", imageMetaName, err)
+		os.Exit(1)
+	}
+}
+
+// fileDigest returns the sha256 content digest of the file at path, in the
+// same "sha256:<hex>" form the server records for registry pulls.
+func fileDigest(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
 }
 
 func installAgent(mnt string) {

--- a/cmd/pyro/build_test.go
+++ b/cmd/pyro/build_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/danievanzyl/pyro/internal/sandbox"
+)
+
+// TestWriteImageSidecar_ReadableByImageManager pins the CLI/server contract:
+// the sidecar build-image writes must be named and shaped so that
+// ImageManager.Get can read it back with a non-blank Source and Digest.
+func TestWriteImageSidecar_ReadableByImageManager(t *testing.T) {
+	imagesDir := t.TempDir()
+	imgDir := filepath.Join(imagesDir, "myimg")
+	if err := os.MkdirAll(imgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	rootfs := filepath.Join(imgDir, "rootfs.ext4")
+	if err := os.WriteFile(rootfs, []byte("fake-rootfs-bytes"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	writeImageSidecar(imgDir, "myimg", "docker://ubuntu:24.04", 512, rootfs)
+
+	sidecar := filepath.Join(imgDir, "image-meta.json")
+	if _, err := os.Stat(sidecar); err != nil {
+		t.Fatalf("expected sidecar at %s: %v", sidecar, err)
+	}
+
+	im, err := sandbox.NewImageManager(sandbox.ImageConfig{ImagesDir: imagesDir}, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := im.Get("myimg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Source == "" {
+		t.Error("expected non-blank Source")
+	}
+	if info.Digest == "" {
+		t.Error("expected non-blank Digest")
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -17,6 +19,9 @@ type Store struct {
 
 // New creates a Store backed by SQLite at the given path.
 func New(dbPath string) (*Store, error) {
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		return nil, fmt.Errorf("create db dir: %w", err)
+	}
 	db, err := sql.Open("sqlite", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite: %w", err)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -18,6 +18,21 @@ func testStore(t *testing.T) *Store {
 	return s
 }
 
+func TestNew_CreatesMissingParentDir(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "nested", "sub", "pyro.db")
+
+	s, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New(%q) with missing parent dir: %v", dbPath, err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("expected db file at %q: %v", dbPath, err)
+	}
+}
+
 func TestCreateAndGetSandbox(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()


### PR DESCRIPTION
Closes #31

## Summary

Three independent, self-contained one-line defects bundled together (no shared code between them):

1. **`pyro build-image` writes the wrong sidecar filename.** It now writes `image-meta.json` (matching the server's `internal/sandbox/images.go:49` sidecar name) instead of `image.json`. Since the CLI never computed a digest before, the sidecar now also records a `sha256:` content digest of the produced `rootfs.ext4` — otherwise the filename fix alone would still leave `Digest` blank, failing the acceptance criterion. Both `buildFromOCI` and `buildMinimal` now share a small `writeImageSidecar`/`fileDigest` helper (`cmd/pyro/build.go`).
2. **`store.New` never created the db's parent directory.** Added `os.MkdirAll(filepath.Dir(dbPath), 0o755)` before `sql.Open` (`internal/store/sqlite.go:20`).
3. **`CLAUDE.md` documented every endpoint without its `/api` prefix.** Every endpoint in the "API Endpoints" section is now prefixed with `/api`, and bare `/health` is recorded as the backward-compat alias.

`cmd/pyro/doctor.go` is unchanged — it already requests `/api/health`, which routes correctly.

## Test plan

- `go vet ./...` — clean.
- UI built first per the build gotcha: `bun install && bun run build` in `ui/`.
- `make test-unit` (`go test -short -v ./internal/...`) at PR head:

      pyro-tests: DISCOVERED=126 RAN=126 PASS=126 FAIL=0 SKIP=0 sha=9da552009b5e2cd267e1575b76904d2045c9ad0f

- Same command at base sha `2649c45d4378ede328933c7d42d7ec16fdc79c0c`:

      pyro-tests: DISCOVERED=125 RAN=125 PASS=125 FAIL=0 SKIP=0 sha=2649c45d4378ede328933c7d42d7ec16fdc79c0c

- Per-test-name diff between the two runs (`./internal/...` scope):
  - Zero test names that pass at base and fail at head.
  - Zero test names present at base and absent at head.
  - One new test name at head not present at base: `TestNew_CreatesMissingParentDir` (covers defect #2).
- Additionally, `go test ./cmd/pyro/...` passes with the new `TestWriteImageSidecar_ReadableByImageManager`, which round-trips a CLI-written sidecar through `sandbox.ImageManager.Get` and asserts non-blank `Source` and `Digest` (this test lives outside `./internal/...` so isn't in the counts above, but is part of the feedback loop for defect #1).

## Intended test removals

None.

## Reviewer axes self-assessment

1. **Correctness** — Passes. All three locked defects are fixed exactly as specified; tests demonstrate the CLI/server sidecar contract and the missing-parent-dir fix.
2. **Scope fidelity** — Passes. Every changed line traces to one of the three defects in #31; `cmd/pyro/doctor.go` is untouched (verified via `git diff --name-only`); no other endpoints or behavior were added.
3. **Regression safety** — Passes. Full `./internal/...` suite is green at head with zero regressions and zero silent removals versus base; pre-existing `name`/`size` fields in the CLI sidecar were preserved, not dropped.
4. **Test quality** — Passes. `TestNew_CreatesMissingParentDir` fails without the `MkdirAll` fix (verified red before green); `TestWriteImageSidecar_ReadableByImageManager` fails without both the filename fix and the digest addition (verified red before green) — neither is tautological.
5. **Lean** — Passes. `/crew:ponytail` confirmed all three fixes are necessary (not speculative) before any test was written; the digest computation reuses stdlib `crypto/sha256` only, no new dependency; the two build call-sites share one small helper instead of duplicating logic.
