### PR TITLE
docs: ADR 0006 — the controller authenticates as a GitHub App (#25)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -68,3 +68,17 @@ the workload. pyro never supplies one — an image that needs services carries i
 own. See `docs/adr/0004-the-runner-image-starts-its-own-services.md`.
 _Avoid_: Entrypoint, init script, startup script (all imply something pyro or the
 image runtime invokes on its own)
+
+**Controller credential**:
+The single GitHub credential the runner controller authenticates with. It is the
+only secret pyro stores, it belongs to the host, and it never enters a sandbox.
+See `docs/adr/0006-the-controller-authenticates-as-a-github-app.md`.
+_Avoid_: Token (unqualified — several different tokens derive from this one), PAT,
+GitHub token
+
+**JIT config**:
+The single-use credential GitHub issues for one job, which a runner presents to
+claim that job and nothing else. It is the only GitHub credential that ever
+reaches a sandbox, and it is independent of the controller credential.
+_Avoid_: Registration token, runner token (both name different, longer-lived
+things in GitHub's own API)

--- a/docs/adr/0006-the-controller-authenticates-as-a-github-app.md
+++ b/docs/adr/0006-the-controller-authenticates-as-a-github-app.md
@@ -1,0 +1,68 @@
+# The runner controller authenticates as a GitHub App, and pyro stores no second credential
+
+The runner controller needs a GitHub credential to register runner scale sets and
+mint per-job JIT configs. It authenticates as a **GitHub App**, installed on
+selected repositories with `Administration: Read and write` and
+`Metadata: Read`. The App's private key is the only secret pyro stores, and it
+lives in a file on the host named by `--github-app-key-file` — never in a flag
+value, never in `deploy/pyro.service`, which is public.
+
+## Considered options
+
+**Classic PAT.** Rejected. It is the only other credential that never expires,
+but its `repo` scope grants code write to every repository the account can
+reach, including repositories owned by unrelated organisations the account is a
+member of. A single-host homelab box should not hold that.
+
+**Fine-grained PAT.** Rejected, and it was the close call — its blast radius is
+identical to the App's, and it is quicker to create. It loses on expiry:
+fine-grained tokens are capped at 366 days, and expiry is silent. The controller
+would start returning 401, jobs would queue in GitHub indefinitely, and nobody
+would notice until someone opened a pull request. A credential that renews
+itself is worth ten minutes of setup on a project with no monitoring.
+
+**GitHub App.** Chosen. Installation tokens renew indefinitely, so the
+credential never expires unattended, and the permission set is bounded to the
+repositories selected at install time. Choosing it costs nothing structurally:
+`github.com/actions/scaleset` offers `NewClientWithGitHubApp` alongside
+`NewClientWithPersonalAccessToken`, and `golang-jwt/jwt` is a static import of
+that library regardless of which one is used. App auth is three config fields
+instead of one.
+
+## Consequences
+
+**Short-lived tokens are not the benefit.** The App private key is a permanent
+secret on the host; host compromise grants indefinite access until the key is
+revoked. The App wins on *scope* and on *never expiring*, and on nothing else.
+`Administration: write` still permits deleting a selected repository or making a
+private one public, which is the real exfiltration path — so the App is
+installed on selected repositories, never on all of them.
+
+**Runner scale sets are repository-scoped.** Every repository that will use
+these runners belongs to a personal account, and GitHub has no user-account-level
+runner. That means one scale set, one message session and one goroutine per
+enabled repository. Moving the repositories into an organisation would collapse
+that to one of each and narrow the permission to org `Self-hosted runners:
+write`, which cannot touch repository contents or settings at all — recorded as
+an available improvement, not a decision taken here.
+
+**pyro holds no second credential.** The controller runs in-process and calls
+`Manager.CreateSandbox` directly, which takes an API key *ID*, not a key. It
+owns a row in `api_keys` for attribution and audit, whose key value is generated
+at startup and never emitted. There is no `pk_` secret to configure, store or
+rotate. Because sandbox reads and deletes are filtered by owning key, runner
+sandboxes are not visible under the operator's own key — the runner UI is where
+they are listed and cancelled.
+
+**Rotation costs in-flight jobs.** Nothing expires in normal operation; the
+client library refreshes every derived token itself. The only rotation event is
+replacing the private key or reinstalling the App, and that needs a restart —
+which destroys every running sandbox, because pyro tears down all active
+sandboxes on `SIGTERM`. Rotate during an idle window. Revoking the credential
+does not stop a job already running: the runner inside the sandbox holds its own
+single-use JIT credential and finishes. New jobs simply stop being picked up.
+
+**Auth failure is reported, not silent.** A revoked or rejected credential
+surfaces as a degraded host-readiness check and an error log, consistent with
+[ADR 0002](0002-host-readiness-is-reported-never-fatal.md). Without that, a
+revoked credential is indistinguishable from an idle queue.


### PR DESCRIPTION
Resolves the auth half of #25.

**Decision.** The runner controller authenticates as a **GitHub App** installed on selected repositories (`Administration: Read and write` + `Metadata: Read`), not a PAT.

- Classic PAT rejected: `repo` scope grants code write to *every* repository the account can reach, including unrelated orgs it belongs to.
- Fine-grained PAT rejected on expiry, not scope — identical blast radius, but capped at 366 days and it expires **silently**: the controller 401s and jobs queue in GitHub forever with no signal.
- App auth costs nothing structurally: `actions/scaleset` ships `NewClientWithGitHubApp`, and `golang-jwt/jwt` is a static import of that library either way.

**Scope is repository-level**, because every candidate repo is under a personal account and GitHub has no user-account-level runner (verified live: `/users/{u}/actions/runners` → 404, `/repos/{o}/{r}/actions/runners` → 200). This overturns #21's org-scope premise.

**pyro stores no second credential.** The in-process controller calls `Manager.CreateSandbox` with an API key *ID*, not a key — there is no `pk_` secret to configure or rotate.

Also adds `Controller credential` and `JIT config` to `CONTEXT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)